### PR TITLE
Use Google Docs viewer to display slides and exercises

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 
 <p>Learning a new programming language is not easy, on top of reading a lot you need to practice even more.</p>
 
-<p>This workshop is designed to teach you some of the basics of F# and Functional Programming by combining theory (<a href="https://github.com/jorgef/fsharpworkshop/raw/master/FSharpWorkshop_Slides.pptx">slides</a>) and practice (<a href="https://github.com/jorgef/fsharpworkshop/raw/master/FSharpWorkshop_Exercises.pdf">exercises</a>).</p>
+<p>This workshop is designed to teach you some of the basics of F# and Functional Programming by combining theory (<a href="https://docs.google.com/viewer?url=https://github.com/jorgef/fsharpworkshop/raw/master/FSharpWorkshop_Slides.pptx">slides</a>) and practice (<a href="https://docs.google.com/viewer?url=https://github.com/jorgef/fsharpworkshop/raw/master/FSharpWorkshop_Exercises.docx">exercises</a>).</p>
 
 <!--<h6>Note: I may be travelling to Europe during June 2015, ping me if you want me to run the workshop somewhere there.&nbsp;&nbsp;<a href="mailto:jorge.fioranelli@gmail.com">jorge.fioranelli@gmail.com</a>&nbsp;/&nbsp;<a href="https://twitter.com/jorgefioranelli">@jorgefioranelli</a></h6>-->
 <h2>


### PR DESCRIPTION
Jorge, just a suggestion for you. I modified the urls to the slides and exercises to use Google Docs. This makes those links friendlier to those of us on different platforms. I didn't have to upload the files to Google Docs, it still use the GitHub raw urls.

The problems I experience with the existing urls was that the link to the pptx downloads it and even link to the .pdf exercises is downloaded. Note that also switch exercises link from the .pdf link to the .docx — I figured that the .pptx and the .docx files are more likely to be up-to-date :-).